### PR TITLE
Add auto page-turn feature

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -202,5 +202,23 @@
     "placeholders": {
       "value": {}
     }
-  }
+  },
+  "autoPageTitle": "Auto page-turn",
+  "autoPageSubtitle": "Advance automatically on a timer",
+  "autoPageIntervalLabel": "Page interval",
+  "autoPageIntervalValue": "Every {seconds}s",
+  "@autoPageIntervalValue": {
+    "placeholders": {
+      "seconds": {
+        "type": "int"
+      }
+    }
+  },
+  "autoPageGranularityLabel": "Advance per tick",
+  "autoPageGranularityPage": "Page",
+  "autoPageGranularityLine": "Line",
+  "shortcutAutoPage": "Auto page-turn",
+  "autoPageOnMessage": "Auto page-turn on",
+  "autoPageOffMessage": "Auto page-turn off",
+  "autoPageReachedEnd": "Reached the end; auto page-turn stopped"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -202,5 +202,23 @@
     "placeholders": {
       "value": {}
     }
-  }
+  },
+  "autoPageTitle": "自动翻页",
+  "autoPageSubtitle": "按设定间隔自动前进",
+  "autoPageIntervalLabel": "翻页间隔",
+  "autoPageIntervalValue": "每 {seconds} 秒",
+  "@autoPageIntervalValue": {
+    "placeholders": {
+      "seconds": {
+        "type": "int"
+      }
+    }
+  },
+  "autoPageGranularityLabel": "每次前进",
+  "autoPageGranularityPage": "整页",
+  "autoPageGranularityLine": "逐行",
+  "shortcutAutoPage": "自动翻页",
+  "autoPageOnMessage": "自动翻页已开启",
+  "autoPageOffMessage": "自动翻页已关闭",
+  "autoPageReachedEnd": "已到达结尾，自动翻页已停止"
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -907,6 +907,72 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{value}°'**
   String sliderDegrees(Object value);
+
+  /// No description provided for @autoPageTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto page-turn'**
+  String get autoPageTitle;
+
+  /// No description provided for @autoPageSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Advance automatically on a timer'**
+  String get autoPageSubtitle;
+
+  /// No description provided for @autoPageIntervalLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Page interval'**
+  String get autoPageIntervalLabel;
+
+  /// No description provided for @autoPageIntervalValue.
+  ///
+  /// In en, this message translates to:
+  /// **'Every {seconds}s'**
+  String autoPageIntervalValue(int seconds);
+
+  /// No description provided for @autoPageGranularityLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Advance per tick'**
+  String get autoPageGranularityLabel;
+
+  /// No description provided for @autoPageGranularityPage.
+  ///
+  /// In en, this message translates to:
+  /// **'Page'**
+  String get autoPageGranularityPage;
+
+  /// No description provided for @autoPageGranularityLine.
+  ///
+  /// In en, this message translates to:
+  /// **'Line'**
+  String get autoPageGranularityLine;
+
+  /// No description provided for @shortcutAutoPage.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto page-turn'**
+  String get shortcutAutoPage;
+
+  /// No description provided for @autoPageOnMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto page-turn on'**
+  String get autoPageOnMessage;
+
+  /// No description provided for @autoPageOffMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto page-turn off'**
+  String get autoPageOffMessage;
+
+  /// No description provided for @autoPageReachedEnd.
+  ///
+  /// In en, this message translates to:
+  /// **'Reached the end; auto page-turn stopped'**
+  String get autoPageReachedEnd;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -460,4 +460,39 @@ class AppLocalizationsEn extends AppLocalizations {
   String sliderDegrees(Object value) {
     return '$value°';
   }
+
+  @override
+  String get autoPageTitle => 'Auto page-turn';
+
+  @override
+  String get autoPageSubtitle => 'Advance automatically on a timer';
+
+  @override
+  String get autoPageIntervalLabel => 'Page interval';
+
+  @override
+  String autoPageIntervalValue(int seconds) {
+    return 'Every ${seconds}s';
+  }
+
+  @override
+  String get autoPageGranularityLabel => 'Advance per tick';
+
+  @override
+  String get autoPageGranularityPage => 'Page';
+
+  @override
+  String get autoPageGranularityLine => 'Line';
+
+  @override
+  String get shortcutAutoPage => 'Auto page-turn';
+
+  @override
+  String get autoPageOnMessage => 'Auto page-turn on';
+
+  @override
+  String get autoPageOffMessage => 'Auto page-turn off';
+
+  @override
+  String get autoPageReachedEnd => 'Reached the end; auto page-turn stopped';
 }

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -440,4 +440,39 @@ class AppLocalizationsZh extends AppLocalizations {
   String sliderDegrees(Object value) {
     return '$value°';
   }
+
+  @override
+  String get autoPageTitle => '自动翻页';
+
+  @override
+  String get autoPageSubtitle => '按设定间隔自动前进';
+
+  @override
+  String get autoPageIntervalLabel => '翻页间隔';
+
+  @override
+  String autoPageIntervalValue(int seconds) {
+    return '每 $seconds 秒';
+  }
+
+  @override
+  String get autoPageGranularityLabel => '每次前进';
+
+  @override
+  String get autoPageGranularityPage => '整页';
+
+  @override
+  String get autoPageGranularityLine => '逐行';
+
+  @override
+  String get shortcutAutoPage => '自动翻页';
+
+  @override
+  String get autoPageOnMessage => '自动翻页已开启';
+
+  @override
+  String get autoPageOffMessage => '自动翻页已关闭';
+
+  @override
+  String get autoPageReachedEnd => '已到达结尾，自动翻页已停止';
 }

--- a/lib/src/reader_app.dart
+++ b/lib/src/reader_app.dart
@@ -195,6 +195,9 @@ class _ReaderSurfaceState extends State<ReaderSurface> with WindowListener {
   OverlayEntry? _messageOverlayEntry;
   Timer? _messageTimer;
   Timer? _locatorHighlightTimer;
+  Timer? _autoPageTimer;
+  bool _autoPageActive = false;
+  int _autoPageIntervalSeconds = ReaderSettings.defaultAutoPageIntervalSeconds;
   bool _windowListenerRegistered = false;
   bool _locatorHighlightVisible = false;
   DateTime? _lastForegroundRecoveryAt;
@@ -517,16 +520,77 @@ class _ReaderSurfaceState extends State<ReaderSurface> with WindowListener {
     return true;
   }
 
-  void _advanceReadingPage() {
+  bool _advanceReadingPage() {
     final stepCount = math.max(1, _visibleVisualLineCapacity);
+    var movedAny = false;
     var animated = false;
     for (var index = 0; index < stepCount; index += 1) {
       final moved = _advanceReadingInternal(animate: !animated);
       if (!moved) {
         break;
       }
+      movedAny = true;
       animated = true;
     }
+    return movedAny;
+  }
+
+  void _syncAutoPageTimer() {
+    final settings = widget.controller.settings;
+    final desiredActive = settings.autoPageEnabled;
+    final desiredInterval = settings.autoPageIntervalSeconds;
+    final unchanged = _autoPageActive == desiredActive &&
+        (!desiredActive || _autoPageIntervalSeconds == desiredInterval);
+    if (unchanged) {
+      return;
+    }
+
+    _autoPageTimer?.cancel();
+    _autoPageTimer = null;
+    _autoPageActive = desiredActive;
+    _autoPageIntervalSeconds = desiredInterval;
+    if (!desiredActive) {
+      return;
+    }
+
+    _autoPageTimer = Timer.periodic(
+      Duration(seconds: desiredInterval),
+      (_) => _autoPageTick(),
+    );
+  }
+
+  void _autoPageTick() {
+    if (!mounted) {
+      return;
+    }
+
+    final settings = widget.controller.settings;
+    final moved = settings.autoPageGranularity == ReaderAutoPageGranularity.line
+        ? _advanceReadingInternal(animate: true)
+        : _advanceReadingPage();
+
+    if (moved || !settings.autoPageEnabled) {
+      return;
+    }
+
+    widget.controller.setAutoPageEnabled(false);
+    final l10n = AppLocalizations.of(context);
+    if (l10n != null) {
+      _showMessage(l10n.autoPageReachedEnd);
+    }
+  }
+
+  void _handleAutoPageShortcut() {
+    final controller = widget.controller;
+    final nextEnabled = !controller.settings.autoPageEnabled;
+    controller.setAutoPageEnabled(nextEnabled);
+    final l10n = AppLocalizations.of(context);
+    if (l10n == null) {
+      return;
+    }
+    _showMessage(
+      nextEnabled ? l10n.autoPageOnMessage : l10n.autoPageOffMessage,
+    );
   }
 
   void _rewindReadingPage() {
@@ -577,6 +641,7 @@ class _ReaderSurfaceState extends State<ReaderSurface> with WindowListener {
     _messageTimer?.cancel();
     _messageOverlayEntry?.remove();
     _locatorHighlightTimer?.cancel();
+    _autoPageTimer?.cancel();
     if (_windowListenerRegistered) {
       windowManager.removeListener(this);
     }
@@ -587,6 +652,7 @@ class _ReaderSurfaceState extends State<ReaderSurface> with WindowListener {
   Widget build(BuildContext context) {
     final controller = widget.controller;
     final settings = controller.settings;
+    _syncAutoPageTimer();
     final l10n = AppLocalizations.of(context)!;
     final fontSize = readerBaseFontSize * settings.fontScale;
     final lineSpacing = settings.lineSpacing;
@@ -860,6 +926,7 @@ class _ReaderSurfaceState extends State<ReaderSurface> with WindowListener {
     addBinding(shortcuts.locateReader, () {
       unawaited(_handleLocateReaderShortcut());
     });
+    addBinding(shortcuts.autoPage, _handleAutoPageShortcut);
 
     return bindings;
   }
@@ -1765,6 +1832,48 @@ class _ReaderControlPanelState extends State<_ReaderControlPanel> {
         title: Text(l10n.punctuationLineBreaksTitle),
         subtitle: Text(l10n.punctuationLineBreaksSubtitle),
       ),
+      SwitchListTile(
+        contentPadding: EdgeInsets.zero,
+        value: controller.settings.autoPageEnabled,
+        onChanged: controller.setAutoPageEnabled,
+        title: Text(l10n.autoPageTitle),
+        subtitle: Text(l10n.autoPageSubtitle),
+      ),
+      Text(l10n.autoPageGranularityLabel),
+      const SizedBox(height: 8),
+      SegmentedButton<ReaderAutoPageGranularity>(
+        segments: [
+          ButtonSegment(
+            value: ReaderAutoPageGranularity.page,
+            label: Text(l10n.autoPageGranularityPage),
+          ),
+          ButtonSegment(
+            value: ReaderAutoPageGranularity.line,
+            label: Text(l10n.autoPageGranularityLine),
+          ),
+        ],
+        selected: <ReaderAutoPageGranularity>{
+          controller.settings.autoPageGranularity,
+        },
+        onSelectionChanged: (selection) {
+          controller.setAutoPageGranularity(selection.first);
+        },
+      ),
+      const SizedBox(height: 12),
+      _SliderRow(
+        label: l10n.autoPageIntervalLabel,
+        value: controller.settings.autoPageIntervalSeconds.toDouble(),
+        min: ReaderSettings.minAutoPageIntervalSeconds.toDouble(),
+        max: ReaderSettings.maxAutoPageIntervalSeconds.toDouble(),
+        divisions:
+            ReaderSettings.maxAutoPageIntervalSeconds -
+            ReaderSettings.minAutoPageIntervalSeconds,
+        displayValue: l10n.autoPageIntervalValue(
+          controller.settings.autoPageIntervalSeconds,
+        ),
+        onChanged: (value) =>
+            controller.setAutoPageIntervalSeconds(value.round()),
+      ),
       const SizedBox(height: 12),
       Text(l10n.languageTitle),
       const SizedBox(height: 8),
@@ -2097,6 +2206,7 @@ class _ReaderControlPanelState extends State<_ReaderControlPanel> {
       ReaderShortcutAction.toggleMode => l10n.shortcutToggleMode,
       ReaderShortcutAction.bossKey => l10n.shortcutBossKey,
       ReaderShortcutAction.locateReader => l10n.shortcutLocateReader,
+      ReaderShortcutAction.autoPage => l10n.shortcutAutoPage,
     };
   }
 

--- a/lib/src/reader_controller.dart
+++ b/lib/src/reader_controller.dart
@@ -255,6 +255,22 @@ class ReaderController extends ChangeNotifier {
     _updateSettings(_settings.copyWith(preferPunctuationLineBreaks: value));
   }
 
+  void setAutoPageEnabled(bool value) {
+    _updateSettings(_settings.copyWith(autoPageEnabled: value));
+  }
+
+  void setAutoPageIntervalSeconds(int value) {
+    _updateSettings(
+      _settings.copyWith(
+        autoPageIntervalSeconds: _normalizeAutoPageInterval(value),
+      ),
+    );
+  }
+
+  void setAutoPageGranularity(ReaderAutoPageGranularity value) {
+    _updateSettings(_settings.copyWith(autoPageGranularity: value));
+  }
+
   void setFontFamilyPreset(ReaderFontFamilyPreset value) {
     _updateSettings(_settings.copyWith(fontFamilyPreset: value));
   }
@@ -540,7 +556,10 @@ class ReaderController extends ChangeNotifier {
         _settings.textColorMode == value.textColorMode &&
         _settings.customTextColorValue == value.customTextColorValue &&
         _settings.textBrightnessFactor == value.textBrightnessFactor &&
-        _settings.shortcutBindings == value.shortcutBindings) {
+        _settings.shortcutBindings == value.shortcutBindings &&
+        _settings.autoPageEnabled == value.autoPageEnabled &&
+        _settings.autoPageIntervalSeconds == value.autoPageIntervalSeconds &&
+        _settings.autoPageGranularity == value.autoPageGranularity) {
       return;
     }
 
@@ -621,6 +640,13 @@ class ReaderController extends ChangeNotifier {
     }
 
     return value.clamp(min, max).toDouble();
+  }
+
+  int _normalizeAutoPageInterval(int value) {
+    return value.clamp(
+      ReaderSettings.minAutoPageIntervalSeconds,
+      ReaderSettings.maxAutoPageIntervalSeconds,
+    );
   }
 
   Future<void> _persistCurrentBookProgress() async {

--- a/lib/src/reader_preferences.dart
+++ b/lib/src/reader_preferences.dart
@@ -50,6 +50,9 @@ class SharedPreferencesReaderPreferencesStore
   static const _customTextColorValueKey = 'reader.customTextColorValue';
   static const _textBrightnessFactorKey = 'reader.textBrightnessFactor';
   static const _shortcutBindingsKey = 'reader.shortcutBindings';
+  static const _autoPageEnabledKey = 'reader.autoPageEnabled';
+  static const _autoPageIntervalSecondsKey = 'reader.autoPageIntervalSeconds';
+  static const _autoPageGranularityKey = 'reader.autoPageGranularity';
   static const _bookshelfKey = 'reader.bookshelf';
 
   final SharedPreferences _preferences;
@@ -142,6 +145,18 @@ class SharedPreferencesReaderPreferencesStore
               ReaderSettings.defaults.textBrightnessFactor,
         ),
         shortcutBindings: _loadShortcutBindings(),
+        autoPageEnabled:
+            _preferences.getBool(_autoPageEnabledKey) ??
+            ReaderSettings.defaults.autoPageEnabled,
+        autoPageIntervalSeconds: _normalizeAutoPageInterval(
+          _preferences.getInt(_autoPageIntervalSecondsKey) ??
+              ReaderSettings.defaults.autoPageIntervalSeconds,
+        ),
+        autoPageGranularity: _enumByName(
+          ReaderAutoPageGranularity.values,
+          _preferences.getString(_autoPageGranularityKey),
+          ReaderSettings.defaults.autoPageGranularity,
+        ),
       ),
       bookshelf: _loadBookshelf(),
     );
@@ -241,6 +256,15 @@ class SharedPreferencesReaderPreferencesStore
       _shortcutBindingsKey,
       jsonEncode(settings.shortcutBindings.toJson()),
     );
+    await _preferences.setBool(_autoPageEnabledKey, settings.autoPageEnabled);
+    await _preferences.setInt(
+      _autoPageIntervalSecondsKey,
+      _normalizeAutoPageInterval(settings.autoPageIntervalSeconds),
+    );
+    await _preferences.setString(
+      _autoPageGranularityKey,
+      settings.autoPageGranularity.name,
+    );
   }
 
   @override
@@ -327,6 +351,13 @@ class SharedPreferencesReaderPreferencesStore
     return value
         .clamp(ReaderSettings.minFontScale, ReaderSettings.maxFontScale)
         .toDouble();
+  }
+
+  int _normalizeAutoPageInterval(int value) {
+    return value.clamp(
+      ReaderSettings.minAutoPageIntervalSeconds,
+      ReaderSettings.maxAutoPageIntervalSeconds,
+    );
   }
 
   double _normalizeDoubleSetting(

--- a/lib/src/reader_settings.dart
+++ b/lib/src/reader_settings.dart
@@ -8,6 +8,8 @@ enum ReaderLanguageMode { system, simplifiedChinese, english }
 
 enum ReaderTextColorMode { adaptive, custom }
 
+enum ReaderAutoPageGranularity { page, line }
+
 class ReaderSettings {
   const ReaderSettings({
     required this.oneLineMode,
@@ -30,6 +32,9 @@ class ReaderSettings {
     required this.customTextColorValue,
     required this.textBrightnessFactor,
     required this.shortcutBindings,
+    required this.autoPageEnabled,
+    required this.autoPageIntervalSeconds,
+    required this.autoPageGranularity,
   });
 
   static const double minTextBrightnessFactor = 0.35;
@@ -44,6 +49,9 @@ class ReaderSettings {
   static const double minWindowOpacity = 0.0;
   static const double maxWindowOpacity = 1.0;
   static const int defaultCustomTextColorValue = 0xFFF4F4F0;
+  static const int minAutoPageIntervalSeconds = 1;
+  static const int maxAutoPageIntervalSeconds = 60;
+  static const int defaultAutoPageIntervalSeconds = 5;
 
   static const ReaderSettings defaults = ReaderSettings(
     oneLineMode: false,
@@ -66,6 +74,9 @@ class ReaderSettings {
     customTextColorValue: defaultCustomTextColorValue,
     textBrightnessFactor: defaultTextBrightnessFactor,
     shortcutBindings: ReaderShortcutBindings.defaults,
+    autoPageEnabled: false,
+    autoPageIntervalSeconds: defaultAutoPageIntervalSeconds,
+    autoPageGranularity: ReaderAutoPageGranularity.page,
   );
 
   final bool oneLineMode;
@@ -88,6 +99,9 @@ class ReaderSettings {
   final int customTextColorValue;
   final double textBrightnessFactor;
   final ReaderShortcutBindings shortcutBindings;
+  final bool autoPageEnabled;
+  final int autoPageIntervalSeconds;
+  final ReaderAutoPageGranularity autoPageGranularity;
 
   static const Object _unset = Object();
 
@@ -112,6 +126,9 @@ class ReaderSettings {
     int? customTextColorValue,
     double? textBrightnessFactor,
     ReaderShortcutBindings? shortcutBindings,
+    bool? autoPageEnabled,
+    int? autoPageIntervalSeconds,
+    ReaderAutoPageGranularity? autoPageGranularity,
   }) {
     return ReaderSettings(
       oneLineMode: oneLineMode ?? this.oneLineMode,
@@ -142,6 +159,10 @@ class ReaderSettings {
       customTextColorValue: customTextColorValue ?? this.customTextColorValue,
       textBrightnessFactor: textBrightnessFactor ?? this.textBrightnessFactor,
       shortcutBindings: shortcutBindings ?? this.shortcutBindings,
+      autoPageEnabled: autoPageEnabled ?? this.autoPageEnabled,
+      autoPageIntervalSeconds:
+          autoPageIntervalSeconds ?? this.autoPageIntervalSeconds,
+      autoPageGranularity: autoPageGranularity ?? this.autoPageGranularity,
     );
   }
 }

--- a/lib/src/reader_shortcuts.dart
+++ b/lib/src/reader_shortcuts.dart
@@ -9,6 +9,7 @@ enum ReaderShortcutAction {
   toggleMode,
   bossKey,
   locateReader,
+  autoPage,
 }
 
 class ReaderShortcutKey {
@@ -70,6 +71,10 @@ class ReaderShortcutKey {
     logicalKeyId: 0x0000000062,
     legacyName: 'keyB',
   );
+  static const keyA = ReaderShortcutKey(
+    logicalKeyId: 0x0000000061,
+    legacyName: 'keyA',
+  );
   static const controlShiftF = ReaderShortcutKey(
     logicalKeyId: 0x0000000066,
     shift: true,
@@ -90,6 +95,7 @@ class ReaderShortcutKey {
     keyP,
     keyM,
     keyB,
+    keyA,
     controlShiftF,
   ];
 
@@ -219,6 +225,7 @@ class ReaderShortcutBindings {
     required this.toggleMode,
     required this.bossKey,
     required this.locateReader,
+    required this.autoPage,
   });
 
   static const ReaderShortcutBindings defaults = ReaderShortcutBindings(
@@ -229,6 +236,7 @@ class ReaderShortcutBindings {
     toggleMode: ReaderShortcutKey.keyM,
     bossKey: ReaderShortcutKey.keyB,
     locateReader: ReaderShortcutKey.controlShiftF,
+    autoPage: ReaderShortcutKey.keyA,
   );
 
   final ReaderShortcutKey nextLine;
@@ -238,6 +246,7 @@ class ReaderShortcutBindings {
   final ReaderShortcutKey toggleMode;
   final ReaderShortcutKey bossKey;
   final ReaderShortcutKey locateReader;
+  final ReaderShortcutKey autoPage;
 
   ReaderShortcutKey keyForAction(ReaderShortcutAction action) {
     return switch (action) {
@@ -248,6 +257,7 @@ class ReaderShortcutBindings {
       ReaderShortcutAction.toggleMode => toggleMode,
       ReaderShortcutAction.bossKey => bossKey,
       ReaderShortcutAction.locateReader => locateReader,
+      ReaderShortcutAction.autoPage => autoPage,
     };
   }
 
@@ -259,6 +269,7 @@ class ReaderShortcutBindings {
     ReaderShortcutKey? toggleMode,
     ReaderShortcutKey? bossKey,
     ReaderShortcutKey? locateReader,
+    ReaderShortcutKey? autoPage,
   }) {
     return ReaderShortcutBindings(
       nextLine: nextLine ?? this.nextLine,
@@ -268,6 +279,7 @@ class ReaderShortcutBindings {
       toggleMode: toggleMode ?? this.toggleMode,
       bossKey: bossKey ?? this.bossKey,
       locateReader: locateReader ?? this.locateReader,
+      autoPage: autoPage ?? this.autoPage,
     );
   }
 
@@ -283,6 +295,7 @@ class ReaderShortcutBindings {
       ReaderShortcutAction.toggleMode => copyWith(toggleMode: key),
       ReaderShortcutAction.bossKey => copyWith(bossKey: key),
       ReaderShortcutAction.locateReader => copyWith(locateReader: key),
+      ReaderShortcutAction.autoPage => copyWith(autoPage: key),
     };
   }
 
@@ -310,6 +323,7 @@ class ReaderShortcutBindings {
       'toggleMode': toggleMode.storageValue,
       'bossKey': bossKey.storageValue,
       'locateReader': locateReader.storageValue,
+      'autoPage': autoPage.storageValue,
     };
   }
 
@@ -330,6 +344,7 @@ class ReaderShortcutBindings {
       toggleMode: decode('toggleMode', defaults.toggleMode),
       bossKey: decode('bossKey', defaults.bossKey),
       locateReader: decode('locateReader', defaults.locateReader),
+      autoPage: decode('autoPage', defaults.autoPage),
     );
   }
 
@@ -342,7 +357,8 @@ class ReaderShortcutBindings {
         other.previousPage == previousPage &&
         other.toggleMode == toggleMode &&
         other.bossKey == bossKey &&
-        other.locateReader == locateReader;
+        other.locateReader == locateReader &&
+        other.autoPage == autoPage;
   }
 
   @override
@@ -354,5 +370,6 @@ class ReaderShortcutBindings {
     toggleMode,
     bossKey,
     locateReader,
+    autoPage,
   );
 }

--- a/openspec/changes/add-auto-page-turn/design.md
+++ b/openspec/changes/add-auto-page-turn/design.md
@@ -1,0 +1,75 @@
+## Context
+
+CheatReader is a keyboard-driven desktop reader where the primary forward action advances one line/segment (down-arrow, space, wheel) and PageDown advances one visible page. For long-form or hands-free reading, users currently have no way to advance automatically. We add an auto page-turn feature that drives the existing forward navigation on a timer, with user control over interval, advance granularity, and a toggle shortcut.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a timer-driven automatic advance that reuses the existing forward/page navigation paths.
+- Let users choose advance granularity: whole page (PageDown-equivalent) or single line/segment (down-arrow-equivalent).
+- Let users choose the interval (1–60 seconds, default 5).
+- Provide a rebindable keyboard shortcut (default `A`) to toggle auto page-turn while reading, with a transient status toast.
+- Persist the enable state, interval, granularity, and shortcut binding alongside other reader settings.
+- Stop automatically and notify when the end of the book is reached.
+
+**Non-Goals:**
+- Sub-second or variable-speed smoothing within a tick (interval is an integer number of seconds).
+- Pausing auto page-turn when the control panel is open (it keeps running behind the dialog; users can toggle it off).
+- Auto-scrolling pixel-by-pixel; we reuse the discrete line/page advance model.
+
+## Decisions
+
+### 1. Drive existing navigation methods instead of a separate advance path
+The timer tick calls `_advanceReadingPage()` (page granularity) or `_advanceReadingInternal(animate: true)` (line granularity) — the same code paths as PageDown / down-arrow.
+
+Rationale: Reuses well-tested segment-wrapping and animation logic in both single-line and multi-line modes; avoids a parallel advance path that could diverge.
+
+Alternatives considered:
+- Always advance one line regardless of granularity. Rejected: does not match the "翻页" (page) semantics requested by users.
+- Add a dedicated `controller.nextAutoStep()`. Rejected: duplicates existing navigation.
+
+### 2. Own the timer in the reader surface, not the controller
+`_ReaderSurfaceState` owns the `Timer.periodic` and reconciles it in `build()` based on `settings.autoPageEnabled` and `autoPageIntervalSeconds`. The controller only holds settings/state.
+
+Rationale: The forward/page advance methods live on the surface (they manage visual segments, animation tokens, and post-frame transitions). The controller's `notifyListeners` already triggers surface rebuilds, so reconciliation in `build` is cheap and consistent with the existing `updateVisibleLineCapacity` post-frame pattern.
+
+Alternatives considered:
+- Timer in the controller calling `controller.nextPage()`. Rejected: bypasses segment/animation handling and would mis-advance in single-line mode.
+
+### 3. Refactor `_advanceReadingPage` to return whether it moved
+Returning a bool lets the tick detect "reached the end" and auto-disable.
+
+Rationale: Prevents a stuck "enabled but no-op" toggle at the end of a book. Existing callers ignore the return value (Dart discards return values for `void Function()` callbacks).
+
+### 4. Persist the enable state by default
+Like every other reader setting, `autoPageEnabled` is persisted and restored on launch.
+
+Rationale: Consistency with the rest of the settings surface; predictable for users who close/reopen mid-read. The shortcut toast and end-of-book auto-stop provide clear feedback.
+
+### 5. Add `autoPage` to the configurable shortcut system with default `A`
+A new `ReaderShortcutAction.autoPage` with default `ReaderShortcutKey.keyA`, exposed in the keyboard-controls recorder.
+
+Rationale: The app is keyboard-driven; toggling auto-page from the keyboard while reading is the expected UX. Additive: old saved bindings without `autoPage` fall back to the default via the existing `fromJson` decode-with-fallback.
+
+## Risks / Trade-offs
+
+- [A periodic timer created during `build` is a side effect] -> Mitigation: guarded by an "unchanged" check so it is only (re)created when enabled state or interval changes; cancelled in `dispose`.
+- [Reaching the end mid-tick] -> Mitigation: tick detects no movement and disables auto-page with a toast.
+- [Possible default-key collision for users who previously remapped another action to `A`] -> Mitigation: additive and low-frequency; the conflict resolver surfaces conflicts on reassignment.
+- [Auto-paging behind an open control panel dialog] -> Mitigation: accepted; harmless and reversible via the shortcut or panel switch.
+
+## Migration Plan
+
+1. Add `ReaderAutoPageGranularity` enum and three settings fields with constants and equality.
+2. Add controller setters (interval clamped 1–60) and preference load/save.
+3. Add `autoPage` shortcut action + `keyA` to the bindings system.
+4. Wire the timer, tick, shortcut handler, and control-panel UI; refactor `_advanceReadingPage` to return bool.
+5. Add localization and regenerate; add tests.
+
+Rollback strategy:
+- Revert the feature commit; persisted auto-page keys remain harmlessly in preferences and are ignored by older builds.
+
+## Open Questions
+
+- Should auto page-turn pause while the control panel dialog is open? (Currently no.)
+- Should the interval allow sub-second values for faster reading? (Currently integer seconds only.)

--- a/openspec/changes/add-auto-page-turn/proposal.md
+++ b/openspec/changes/add-auto-page-turn/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+阅读时需要手动不断翻页，长时间阅读容易疲劳，也无法在阅读时解放双手（例如边读边做笔记）。希望阅读器能按可配置的速度自动前进，并保留对前进粒度和触发节奏的完全控制。
+
+## What Changes
+
+- 新增「自动翻页」开关，开启后按设定间隔自动前进阅读内容。
+- 新增可配置的翻页间隔（1–60 秒，默认 5 秒）。
+- 新增可配置的前进粒度：「整页」（每次推进一屏可见行，等价 PageDown）或「逐行」（每次推进一行/段，等价下方向键）。
+- 新增可自定义的快捷键（默认 `A`）用于在阅读时随手开关自动翻页，并通过 toast 提示当前状态。
+- 到达书末无法继续前进时，自动关闭翻页并提示。
+- 所有相关设置随现有偏好一并持久化。
+
+## Capabilities
+
+### New Capabilities
+- None.
+
+### Modified Capabilities
+- `reader-navigation-controls`: 新增「自动翻页」导航方式，按计时器按设定粒度自动前进，并在到达结尾时停止。
+- `reader-control-panel`: 在阅读设置区暴露自动翻页开关、粒度与间隔控件，以及对应的快捷键录制项。
+
+## Impact
+
+- 受影响代码：`lib/src/reader_settings.dart`、`lib/src/reader_controller.dart`、`lib/src/reader_preferences.dart`、`lib/src/reader_shortcuts.dart`、`lib/src/reader_app.dart`，以及本地化资源（`lib/l10n/*.arb` 与生成文件）。
+- 新增键盘动作 `autoPage`（默认 `A`），与现有可定制快捷键系统一致；对已有用户向后兼容（旧偏好缺失该键时回退默认）。
+- 无外部 API 变更；属阅读交互与设置增强。
+- 需补充自动翻页在多行/单行模式下的手动验证，以及到结尾自动停止的行为。

--- a/openspec/changes/add-auto-page-turn/specs/reader-control-panel/spec.md
+++ b/openspec/changes/add-auto-page-turn/specs/reader-control-panel/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Auto page-turn settings
+The control panel SHALL expose auto page-turn controls in the reading-settings section, including an enable toggle, an advance-granularity choice (page or line), and a page-turn interval, alongside a rebindable keyboard shortcut for toggling auto page-turn.
+
+#### Scenario: Toggle auto page-turn from panel
+- **WHEN** the user toggles the auto page-turn switch in the control panel
+- **THEN** auto page-turn is enabled or disabled immediately
+
+#### Scenario: Choose advance granularity
+- **WHEN** the user selects page or line granularity in the control panel
+- **THEN** subsequent auto page-turn ticks use the selected granularity
+
+#### Scenario: Adjust page-turn interval
+- **WHEN** the user drags the interval slider
+- **THEN** the interval is clamped to the supported range (1–60 seconds) and applied to the running timer
+
+#### Scenario: Rebind auto page-turn shortcut
+- **WHEN** the user records a new key for the auto page-turn action in the keyboard-controls section
+- **THEN** the new shortcut is saved and conflicts with other actions are rejected

--- a/openspec/changes/add-auto-page-turn/specs/reader-navigation-controls/spec.md
+++ b/openspec/changes/add-auto-page-turn/specs/reader-navigation-controls/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Automatic page-turn
+The system SHALL support an automatic page-turn mode that advances the reading position on a configurable timer, using either whole-page or single-line advancement granularity, and SHALL stop automatically when no further forward movement is possible.
+
+#### Scenario: Enable auto page-turn
+- **WHEN** the user enables auto page-turn
+- **THEN** the reader begins advancing the reading position on the configured interval
+
+#### Scenario: Advance by whole page
+- **WHEN** auto page-turn is enabled with page granularity
+- **THEN** each tick advances the reading position by one visible page, equivalent to the next-page action
+
+#### Scenario: Advance by single line
+- **WHEN** auto page-turn is enabled with line granularity
+- **THEN** each tick advances the reading position by one line or segment, equivalent to the next-line action
+
+#### Scenario: Change interval while running
+- **WHEN** the user changes the page-turn interval while auto page-turn is enabled
+- **THEN** the next tick fires after the newly configured interval without requiring a manual toggle
+
+#### Scenario: Stop at end of content
+- **WHEN** a tick cannot advance the reading position any further and auto page-turn is enabled
+- **THEN** the reader disables auto page-turn and notifies the user
+
+#### Scenario: Toggle via keyboard shortcut
+- **WHEN** the user presses the configured auto page-turn shortcut
+- **THEN** the reader toggles auto page-turn on or off and shows a transient status message
+
+#### Scenario: Persist auto page-turn state
+- **WHEN** the user reopens the reader after closing it
+- **THEN** the saved auto page-turn enable state, interval, and granularity are restored

--- a/openspec/changes/add-auto-page-turn/tasks.md
+++ b/openspec/changes/add-auto-page-turn/tasks.md
@@ -1,0 +1,35 @@
+## 1. Settings and persistence
+
+- [x] 1.1 Add `ReaderAutoPageGranularity` enum and `autoPageEnabled` / `autoPageIntervalSeconds` / `autoPageGranularity` fields to `ReaderSettings` with constants (min 1, max 60, default 5) and `copyWith`/equality.
+- [x] 1.2 Add controller setters `setAutoPageEnabled`, `setAutoPageIntervalSeconds` (clamped), `setAutoPageGranularity`.
+- [x] 1.3 Add preference keys and load/save for the three new settings, with safe fallbacks.
+
+## 2. Shortcut
+
+- [x] 2.1 Add `ReaderShortcutAction.autoPage` and `ReaderShortcutKey.keyA` (legacy name `keyA`).
+- [x] 2.2 Wire `autoPage` into `ReaderShortcutBindings` (defaults, keyForAction, copyWith, copyWithAction, toJson, fromJson, ==, hashCode).
+- [x] 2.3 Bind the shortcut to a toggle handler that shows an on/off toast.
+
+## 3. Reader surface timer
+
+- [x] 3.1 Add `_autoPageTimer` and `_syncAutoPageTimer()` reconciling on enabled/interval changes; call from `build()`, cancel in `dispose()`.
+- [x] 3.2 Add `_autoPageTick()` dispatching by granularity (page vs line).
+- [x] 3.3 Refactor `_advanceReadingPage()` to return whether it moved.
+- [x] 3.4 Auto-disable and toast when the end is reached.
+
+## 4. Control panel UI
+
+- [x] 4.1 Add an auto page-turn switch in the reading-settings section.
+- [x] 4.2 Add a granularity `SegmentedButton` (page / line).
+- [x] 4.3 Add an interval `_SliderRow` (1–60s) with localized display value.
+- [x] 4.4 Add the `autoPage` case to the shortcut label switch.
+
+## 5. Localization
+
+- [x] 5.1 Add 11 new strings (en + zh) to `.arb` files and regenerate via `flutter gen-l10n`.
+
+## 6. Validation
+
+- [x] 6.1 Add a controller test for auto-page settings persistence and interval clamping; extend the existing preferences round-trip test.
+- [x] 6.2 `flutter analyze` clean; `flutter test` green.
+- [ ] 6.3 Manually validate: enable/disable via shortcut and panel, page vs line granularity, interval change while running, end-of-book auto-stop, persistence across restart.

--- a/test/reader_controller_test.dart
+++ b/test/reader_controller_test.dart
@@ -337,6 +337,59 @@ void main() {
       );
     });
 
+    test('auto page settings persist and clamp the interval', () async {
+      final store = MemoryReaderPreferencesStore();
+      final controller = ReaderController(
+        initialContent: 'One\nTwo\nThree',
+        preferencesStore: store,
+        windowController: FakePlatformWindowController(),
+        fileBookmarkService: FakeReaderFileBookmarkService(),
+        importService: FakeReaderImportService(),
+        libraryStorage: MemoryReaderLibraryStorage(),
+      );
+
+      await controller.initialize();
+
+      expect(controller.settings.autoPageEnabled, isFalse);
+      expect(
+        controller.settings.autoPageIntervalSeconds,
+        ReaderSettings.defaultAutoPageIntervalSeconds,
+      );
+      expect(
+        controller.settings.autoPageGranularity,
+        ReaderAutoPageGranularity.page,
+      );
+
+      controller.setAutoPageEnabled(true);
+      controller.setAutoPageIntervalSeconds(99);
+      controller.setAutoPageGranularity(ReaderAutoPageGranularity.line);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(controller.settings.autoPageEnabled, isTrue);
+      expect(
+        controller.settings.autoPageIntervalSeconds,
+        ReaderSettings.maxAutoPageIntervalSeconds,
+      );
+      expect(
+        controller.settings.autoPageGranularity,
+        ReaderAutoPageGranularity.line,
+      );
+
+      controller.setAutoPageIntervalSeconds(0);
+      expect(
+        controller.settings.autoPageIntervalSeconds,
+        ReaderSettings.minAutoPageIntervalSeconds,
+      );
+
+      final saved = await store.loadSnapshot();
+      expect(saved.settings.autoPageEnabled, isTrue);
+      expect(
+        saved.settings.autoPageIntervalSeconds,
+        ReaderSettings.minAutoPageIntervalSeconds,
+      );
+      expect(saved.settings.autoPageGranularity, ReaderAutoPageGranularity.line);
+    });
+
     test('rejects conflicting shortcut assignments', () async {
       final controller = ReaderController(
         initialContent: 'One\nTwo',
@@ -679,6 +732,9 @@ void main() {
         customTextColorValue: 0xFF0F766E,
         textBrightnessFactor: 0.6,
         shortcutBindings: ReaderShortcutBindings.defaults,
+        autoPageEnabled: true,
+        autoPageIntervalSeconds: 12,
+        autoPageGranularity: ReaderAutoPageGranularity.line,
       );
 
       await store.saveSettings(settings);
@@ -715,6 +771,12 @@ void main() {
       expect(loaded.settings.textBrightnessFactor, 0.6);
       expect(loaded.settings.textColorMode, ReaderTextColorMode.custom);
       expect(loaded.settings.customTextColorValue, 0xFF0F766E);
+      expect(loaded.settings.autoPageEnabled, isTrue);
+      expect(loaded.settings.autoPageIntervalSeconds, 12);
+      expect(
+        loaded.settings.autoPageGranularity,
+        ReaderAutoPageGranularity.line,
+      );
       expect(loaded.bookshelf.single.path, '/tmp/book.txt');
       expect(loaded.bookshelf.single.burnModeEnabled, isFalse);
       expect(loaded.bookshelf.single.fileBookmark, 'bookmark:/tmp/book.txt');


### PR DESCRIPTION
## What

Adds an auto page-turn (自动翻页) feature to CheatReader. The reader automatically advances content on a configurable timer, so long-form or hands-free reading no longer requires constant manual paging.

## Features

- **Enable/disable** via a control-panel switch or a rebindable keyboard shortcut (default `A`).
- **Interval**: 1–60 seconds per tick (default 5). Slider in Reading Settings.
- **Granularity**: whole page (PageDown-equivalent) or single line/segment (down-arrow-equivalent).
- **Auto-stop**: when the end of the book is reached, auto page-turn disables itself and shows a toast.
- **Persistence**: enable state, interval, granularity, and shortcut binding are saved alongside other reader settings.

## How it works

The periodic timer lives in `_ReaderSurfaceState` and reconciles on `build()` based on `autoPageEnabled` + `autoPageIntervalSeconds`. Each tick drives the existing forward navigation paths (`_advanceReadingPage()` for page granularity, `_advanceReadingInternal()` for line granularity), so segment wrapping and animations behave identically to manual PageDown / down-arrow. `_advanceReadingPage()` now returns whether it moved, letting the tick detect end-of-content and auto-disable.

## openspec

Follows the repo's spec-driven workflow: `openspec/changes/add-auto-page-turn/` (proposal, design, tasks, and delta specs for `reader-navigation-controls` and `reader-control-panel`).

## Verification

- `flutter analyze` — clean
- `flutter test` — 61 passing (new test for settings persistence + interval clamping; existing preferences round-trip test extended)
- Manual validation (page/line granularity, interval change while running, end-of-book auto-stop, persistence across restart) is tracked as task 6.3 in `tasks.md`.

## Notes

- The unrelated working-tree changes to `android/gradle.properties` and `pubspec.lock` (Flutter migrator additions / lockfile churn) were intentionally excluded from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
